### PR TITLE
Fix clean target is not cleaning intermediate folders

### DIFF
--- a/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
@@ -28,7 +28,7 @@
 
 	<Target Name="UnoSourceGeneratorClean"
 					BeforeTargets="Clean">
-		<RemoveDir Directories="$(UnoSourceGeneratorOutputPath)\g" />
+		<RemoveDir Directories="$(_UnoSourceGeneratorOutputPath)\g" />
 	</Target>
 
 	<Target Name="_InjectGeneratedFiles"


### PR DESCRIPTION
Makes the clean target injection remove intermediate files, making a rebuild actually start from scratch.