### PR TITLE
Add support for inner-msbuild binlog output generation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,13 +182,18 @@ This will open another visual studio instance, and allow for stepping through th
 
 ## Troubleshooting
 
-### Genration output
+### Generation output
 
 The source generator provides additional details when building, when running the `_UnoSourceGenerator` msbuild target.
 
 To view this information either place visual studio in `details` verbosity (**Options**, **Projects and Solutions**,
 **Build and Run** then **MSBuild project build output verbosity**) or by using the excellent
 [MSBuild Binary and Structured Log Viewer](http://msbuildlog.com/) from [Kirill Osenkov](https://twitter.com/KirillOsenkov).
+
+The source generation target also produces `binlog` file in the output folder, used to troubleshoot issues with the msbuild instance
+created inside the application domain used to generate the code. The path for those files can be altered using the
+`UnoSourceGeneratorBinLogOutputPath` msbuild property. In the context of a VSTS build, setting it to `$(build.artifactstagingdirectory)`
+allows for an improved diagnostics experience.
 
 ### Generated code & Intellisense
 

--- a/readme.md
+++ b/readme.md
@@ -190,10 +190,12 @@ To view this information either place visual studio in `details` verbosity (**Op
 **Build and Run** then **MSBuild project build output verbosity**) or by using the excellent
 [MSBuild Binary and Structured Log Viewer](http://msbuildlog.com/) from [Kirill Osenkov](https://twitter.com/KirillOsenkov).
 
-The source generation target also produces `binlog` file in the output folder, used to troubleshoot issues with the msbuild instance
+The source generation target can also optionally produces `binlog` file in the obj folder, used to troubleshoot issues with the msbuild instance
 created inside the application domain used to generate the code. The path for those files can be altered using the
 `UnoSourceGeneratorBinLogOutputPath` msbuild property. In the context of a VSTS build, setting it to `$(build.artifactstagingdirectory)`
-allows for an improved diagnostics experience.
+allows for an improved diagnostics experience. Set the `UnoSourceGeneratorUnsecureBinLogEnabled` property to true to enabled binary logging.
+
+> **Important**: The binary logger may leak secret environment variables, it is a best practice to never enable this feature as part of normal build.
 
 ### Generated code & Intellisense
 

--- a/src/Uno.SampleProject/Uno.SampleProject.csproj
+++ b/src/Uno.SampleProject/Uno.SampleProject.csproj
@@ -22,6 +22,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>
     </CodeAnalysisRuleSet>
+	<UnoSourceGeneratorUnsecureBinLogEnabled>true</UnoSourceGeneratorUnsecureBinLogEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Uno.SourceGenerationHost.Shared/BuildEnvironment.cs
+++ b/src/Uno.SourceGenerationHost.Shared/BuildEnvironment.cs
@@ -29,6 +29,7 @@ namespace Uno.SourceGeneratorTasks
 		public string VisualStudioVersion { get; }
 		public string TargetFrameworkRootPath { get; }
 		public string BinLogOutputPath { get; }
+		public string BinLogEnabled { get; }
 
 		public BuildEnvironment(
 			string configuration,
@@ -38,7 +39,8 @@ namespace Uno.SourceGeneratorTasks
 			string targetFramework,
 			string visualStudioVersion,
 			string targetFrameworkRootPath,
-			string binLogOutputPath
+			string binLogOutputPath,
+			bool binLogEnabled
 		)
 		{
 			Configuration = configuration;

--- a/src/Uno.SourceGenerationHost.Shared/BuildEnvironment.cs
+++ b/src/Uno.SourceGenerationHost.Shared/BuildEnvironment.cs
@@ -28,8 +28,18 @@ namespace Uno.SourceGeneratorTasks
 		public string TargetFramework { get; }
 		public string VisualStudioVersion { get; }
 		public string TargetFrameworkRootPath { get; }
+		public string BinLogOutputPath { get; }
 
-		public BuildEnvironment(string configuration, string platform, string projectFile, string outputPath, string targetFramework, string visualStudioVersion, string targetFrameworkRootPath)
+		public BuildEnvironment(
+			string configuration,
+			string platform,
+			string projectFile,
+			string outputPath,
+			string targetFramework,
+			string visualStudioVersion,
+			string targetFrameworkRootPath,
+			string binLogOutputPath
+		)
 		{
 			Configuration = configuration;
 			Platform = platform;
@@ -38,6 +48,7 @@ namespace Uno.SourceGeneratorTasks
 			TargetFramework = targetFramework;
 			VisualStudioVersion = visualStudioVersion;
 			TargetFrameworkRootPath = targetFrameworkRootPath;
+			BinLogOutputPath = binLogOutputPath;
 		}
 	}
 }

--- a/src/Uno.SourceGenerator.Console/Program.cs
+++ b/src/Uno.SourceGenerator.Console/Program.cs
@@ -49,7 +49,8 @@ namespace Uno.SourceGeneratorTasks.Console
 					targetFramework: null,
 					visualStudioVersion: "15.0",
 					targetFrameworkRootPath: Path.GetDirectoryName(new Uri(typeof(Microsoft.Build.Logging.ConsoleLogger).Assembly.CodeBase).LocalPath),
-					binLogOutputPath: null
+					binLogOutputPath: null,
+					binLogEnabled: false
 				)
 			);
 

--- a/src/Uno.SourceGenerator.Console/Program.cs
+++ b/src/Uno.SourceGenerator.Console/Program.cs
@@ -48,7 +48,8 @@ namespace Uno.SourceGeneratorTasks.Console
 					outputPath: @"C:\s\TuneInWin10\TuneIn.Core.Uwa\obj\g\test",
 					targetFramework: null,
 					visualStudioVersion: "15.0",
-					targetFrameworkRootPath: Path.GetDirectoryName(new Uri(typeof(Microsoft.Build.Logging.ConsoleLogger).Assembly.CodeBase).LocalPath)
+					targetFrameworkRootPath: Path.GetDirectoryName(new Uri(typeof(Microsoft.Build.Logging.ConsoleLogger).Assembly.CodeBase).LocalPath),
+					binLogOutputPath: null
 				)
 			);
 

--- a/src/Uno.SourceGenerator.Console/Uno.SourceGenerator.Console.csproj
+++ b/src/Uno.SourceGenerator.Console/Uno.SourceGenerator.Console.csproj
@@ -49,16 +49,16 @@
       <Version>4.5.25</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Engine">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Tasks.Core">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">
       <Version>1.3.1</Version>

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Uno.SourceGeneratorTasks.Dev15.0.csproj
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Uno.SourceGeneratorTasks.Dev15.0.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;HAS_BINLOG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet />
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;HAS_BINLOG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet />
@@ -51,19 +51,19 @@
       <Version>1.9.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Tasks.Core">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>15.1.1012</Version>
+      <Version>15.4.8</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis">

--- a/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
@@ -96,16 +96,17 @@
 		</PropertyGroup>
 
 	  <SourceGenerationTask_v0 ProjectFile="$(MSBuildProjectFullPath)"
-													OutputPath="$(_UnoSourceGeneratorOutputPath)\g"
-													Configuration="$(Configuration)"
-													SourceGenerators="@(SourceGenerator)"
-													Platform="$(Platform)"
-													VisualStudioVersion="$(VisualStudioVersion)"
-													TargetFramework="$(SourceGeneratorTargetFramework)"
-													TargetFrameworkRootPath="$(TargetFrameworkRootPath)"
-													AdditionalAssemblies="@(SourceGeneratorAdditionalAssemblies)"
-													BinLogOutputPath="$(UnoSourceGeneratorBinLogOutputPath)"
-													Condition="$(_hasSourceGenerators)">
+								OutputPath="$(_UnoSourceGeneratorOutputPath)\g"
+								Configuration="$(Configuration)"
+								SourceGenerators="@(SourceGenerator)"
+								Platform="$(Platform)"
+								VisualStudioVersion="$(VisualStudioVersion)"
+								TargetFramework="$(SourceGeneratorTargetFramework)"
+								TargetFrameworkRootPath="$(TargetFrameworkRootPath)"
+								AdditionalAssemblies="@(SourceGeneratorAdditionalAssemblies)"
+								BinLogOutputPath="$(UnoSourceGeneratorBinLogOutputPath)"
+								BinLogEnabled="$(UnoSourceGeneratorUnsecureBinLogEnabled)"
+								Condition="$(_hasSourceGenerators)">
 			<Output TaskParameter="GenereratedFiles" ItemName="UnoGeneratedFiles" />
 		</SourceGenerationTask_v0>
 

--- a/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
@@ -4,7 +4,7 @@
 		<UnoSourceGeneratorTasksPath Condition="'$(UnoSourceGeneratorTasksPath)'=='' and '$(MSBuildToolsVersion)'=='14.0'">..\Dev14.0</UnoSourceGeneratorTasksPath>
 		<UnoSourceGeneratorTasksPath Condition="'$(UnoSourceGeneratorTasksPath)'=='' and '$(MSBuildToolsVersion)'=='15.0'">..\Dev15.0</UnoSourceGeneratorTasksPath>
 		<UnoSourceGeneration_FixIntellisense Condition="'$(UnoSourceGeneration_FixIntellisense)'==''">true</UnoSourceGeneration_FixIntellisense>
-
+	  
 		<_UnoSourceGeneratorOutputPath Condition="'$(UnoSourceGeneratorOutputPath)'==''">$(IntermediateOutputPath)</_UnoSourceGeneratorOutputPath>
 		<_UnoSourceGeneratorOutputPath Condition="'$(UnoSourceGeneratorOutputPath)'!=''">$(UnoSourceGeneratorOutputPath)</_UnoSourceGeneratorOutputPath>
 
@@ -81,6 +81,8 @@
 			<!-- Don't spin up the generators task if there are no source generators -->
 			<_hasSourceGenerators>true</_hasSourceGenerators>
 			<_hasSourceGenerators Condition="'@(SourceGenerator)'=='' and '$(VisualStudioVersion)' &gt; '15.0'">false</_hasSourceGenerators>
+
+			<UnoSourceGeneratorBinLogOutputPath Condition="'$(UnoSourceGeneratorBinLogOutputPath)'==''">$(IntermediateOutputPath)</UnoSourceGeneratorBinLogOutputPath>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(_UnoSourceGeneratorProjectType)'=='ios' or '$(_UnoSourceGeneratorProjectType)'=='mac'">
@@ -93,7 +95,7 @@
 			<SourceGeneratorTargetFrameworkRootPath Condition="'$(SourceGeneratorTargetFrameworkRootPath)'==''">$(TargetFrameworkRootPathSearchPathsOSX)</SourceGeneratorTargetFrameworkRootPath>
 		</PropertyGroup>
 
-		<SourceGenerationTask_v0 ProjectFile="$(MSBuildProjectFullPath)"
+	  <SourceGenerationTask_v0 ProjectFile="$(MSBuildProjectFullPath)"
 													OutputPath="$(_UnoSourceGeneratorOutputPath)\g"
 													Configuration="$(Configuration)"
 													SourceGenerators="@(SourceGenerator)"
@@ -102,6 +104,7 @@
 													TargetFramework="$(SourceGeneratorTargetFramework)"
 													TargetFrameworkRootPath="$(TargetFrameworkRootPath)"
 													AdditionalAssemblies="@(SourceGeneratorAdditionalAssemblies)"
+													BinLogOutputPath="$(UnoSourceGeneratorBinLogOutputPath)"
 													Condition="$(_hasSourceGenerators)">
 			<Output TaskParameter="GenereratedFiles" ItemName="UnoGeneratedFiles" />
 		</SourceGenerationTask_v0>

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -62,6 +62,8 @@ namespace Uno.SourceGeneratorTasks
 
 		public string OutputPath { get; set; }
 
+		public string BinLogOutputPath { get; set; }
+
 		[Output]
 		public string[] GenereratedFiles { get; set; }
 
@@ -189,7 +191,16 @@ namespace Uno.SourceGeneratorTasks
 
 				Logger.RemotableLogger2 remotableLogger = new Logger.RemotableLogger2(_taskLogger.CreateLogger("Logger.RemotableLogger"));
 
-				var environment = new BuildEnvironment(Configuration, Platform, ProjectFile, OutputPath, TargetFramework, VisualStudioVersion, TargetFrameworkRootPath);
+				var environment = new BuildEnvironment(
+					Configuration,
+					Platform,
+					ProjectFile,
+					OutputPath,
+					TargetFramework,
+					VisualStudioVersion,
+					TargetFrameworkRootPath,
+					BinLogOutputPath
+				);
 
 				GenereratedFiles = hostEntry.Wrapper.Generate(remotableLogger, environment);
 			}

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -64,6 +64,8 @@ namespace Uno.SourceGeneratorTasks
 
 		public string BinLogOutputPath { get; set; }
 
+		public bool BinLogEnabled { get; set; }
+
 		[Output]
 		public string[] GenereratedFiles { get; set; }
 
@@ -199,7 +201,8 @@ namespace Uno.SourceGeneratorTasks
 					TargetFramework,
 					VisualStudioVersion,
 					TargetFrameworkRootPath,
-					BinLogOutputPath
+					BinLogOutputPath,
+					BinLogEnabled
 				);
 
 				GenereratedFiles = hostEntry.Wrapper.Generate(remotableLogger, environment);


### PR DESCRIPTION
Add support for BinaryLogger in the context of inner msbuild instances, for troubleshooting purposes.