### PR TITLE
Fix issue when setting AdditionalAssemblies

### DIFF
--- a/src/Uno.SourceGenerator.Console/Program.cs
+++ b/src/Uno.SourceGenerator.Console/Program.cs
@@ -39,6 +39,7 @@ namespace Uno.SourceGeneratorTasks.Console
 		{
 			// var generator = Build();
 			var generator = new SourceGeneratorHostWrapper();
+			generator.Initialize();
 			var output = generator.Generate(
 				logger: null,
 				environment: new BuildEnvironment(

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -258,6 +258,8 @@ namespace Uno.SourceGeneratorTasks
 			newHost.MSBuildBasePath = msbuildBasePath;
 			newHost.AdditionalAssemblies = AdditionalAssemblies;
 
+			newHost.Initialize();
+
 			hostEntry = (newHost, domain);
 			return hostEntry;
 		}


### PR DESCRIPTION
Addresses an issues where `AdditionalAssemblies` were incorrectly skipped because of the assembly loading sequence with ApplyCacheFolderMSBuildWorkaround.
