### PR TITLE
Improve diagnostics and reliability

### DIFF
--- a/src/Uno.SourceGeneration.Host/AssemblyResolver.cs
+++ b/src/Uno.SourceGeneration.Host/AssemblyResolver.cs
@@ -11,6 +11,8 @@ namespace Uno.SourceGeneration.Host
 {
 	public class AssemblyResolver
 	{
+		private static bool _additionalAssembliesPreloaded;
+
 		public static void RegisterAssemblyLoader(BuildEnvironment environment)
 		{
 			// Force assembly loader to consider siblings, when running in a separate appdomain.
@@ -118,16 +120,21 @@ namespace Uno.SourceGeneration.Host
 
 		private static void TryLoadAdditionalAssemblies(BuildEnvironment environment)
 		{
-			foreach (var assemblyPath in environment.AdditionalAssemblies ?? new string[0])
+			if (!_additionalAssembliesPreloaded)
 			{
-				try
+				_additionalAssembliesPreloaded = true;
+
+				foreach (var assemblyPath in environment.AdditionalAssemblies ?? new string[0])
 				{
-					var assembly = Assembly.LoadFrom(assemblyPath);
-					typeof(AssemblyResolver).Log().Debug($"Preloaded additional assembly [{assembly.FullName}] from [{assemblyPath}]");
-				}
-				catch (Exception e)
-				{
-					typeof(AssemblyResolver).Log().Debug($"Failed to load additional assembly from [{assemblyPath}]", e);
+					try
+					{
+						var assembly = Assembly.LoadFrom(assemblyPath);
+						typeof(AssemblyResolver).Log().Debug($"Preloaded additional assembly [{assembly.FullName}] from [{assemblyPath}]");
+					}
+					catch (Exception e)
+					{
+						typeof(AssemblyResolver).Log().Debug($"Failed to load additional assembly from [{assemblyPath}]", e);
+					}
 				}
 			}
 		}

--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -29,21 +29,21 @@
 	  <ExcludeAssets>runtime</ExcludeAssets>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis">
-	  <Version>2.9.0-beta8-63119-12</Version>
+	  <Version>2.9.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.Common">
-	  <Version>2.9.0-beta8-63119-12</Version>
+	  <Version>2.9.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-	  <Version>2.9.0-beta8-63119-12</Version>
+	  <Version>2.9.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-	  <Version>2.9.0-beta8-63119-12</Version>
+	  <Version>2.9.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-	  <Version>2.9.0-beta8-63119-12</Version>
+	  <Version>2.9.0</Version>
 	</PackageReference>
-	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0-beta8-63119-12" />
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
 	<PackageReference Include="Microsoft.DiaSymReader" Version="1.3.0" />
 	<PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.7.0" />
 	<PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.5.0" />

--- a/src/Uno.SourceGenerationHost.Shared/ProjectDetails.cs
+++ b/src/Uno.SourceGenerationHost.Shared/ProjectDetails.cs
@@ -22,7 +22,7 @@ using Microsoft.Build.Evaluation;
 
 namespace Uno.SourceGeneration.Host
 {
-	public class ProjectDetails
+	public class ProjectDetails : IDisposable
 	{
 		private Tuple<string, DateTime>[] _timeStamps;
 
@@ -32,7 +32,7 @@ namespace Uno.SourceGeneration.Host
 		public string IntermediatePath { get; internal set; }
 		public Project LoadedProject { get; internal set; }
 		public string[] References { get; internal set; }
-
+		public ProjectCollection Collection { get; internal set; }
 
 		public void BuildImportsMap()
 		{
@@ -42,6 +42,11 @@ namespace Uno.SourceGeneration.Host
 				.Concat(new[] { new Tuple<string, DateTime>(ExecutedProject.FullPath, File.GetLastWriteTime(ExecutedProject.FullPath)) })
 				.OrderBy(t => t.Item1)
 				.ToArray();
+		}
+
+		public void Dispose()
+		{
+			Collection?.Dispose();
 		}
 
 		public bool HasChanged()


### PR DESCRIPTION
- Don't reload preloaded assemblies multiple times 
- Update Roslyn to 2.9.0 stable 
- Keep the ProjectCollection alive along the generation