### PR TITLE
Improved logging when the host is used.

### DIFF
--- a/src/Uno.SourceGeneration.Host/Program.cs
+++ b/src/Uno.SourceGeneration.Host/Program.cs
@@ -24,11 +24,14 @@ namespace Uno.SourceGeneration.Host
 				// Uncomment this for easier debugging
 				// Debugger.Launch();
 
-				LogExtensionPoint.AmbientLoggerFactory.AddProvider(new ConsoleLoggerProvider((t, l) => true, true));
-
-				if (args.Length != 3)
+				if (args.Length < 3 || args.Length > 4)
 				{
 					throw new Exception($"Response file, output path and binlog path are required.");
+				}
+
+				if (args.Length == 4 && args[3].Equals("-console", StringComparison.OrdinalIgnoreCase))
+				{
+					LogExtensionPoint.AmbientLoggerFactory.AddProvider(new ConsoleLoggerProvider((t, l) => true, true));
 				}
 
 				var responseFilePath = args[0];

--- a/src/Uno.SourceGeneration.Host/Program.cs
+++ b/src/Uno.SourceGeneration.Host/Program.cs
@@ -6,6 +6,9 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
 using Uno.SourceGeneration.Helpers;
 using Uno.SourceGeneratorTasks;
 using Uno.SourceGeneratorTasks.Helpers;
@@ -21,9 +24,11 @@ namespace Uno.SourceGeneration.Host
 				// Uncomment this for easier debugging
 				// Debugger.Launch();
 
+				LogExtensionPoint.AmbientLoggerFactory.AddProvider(new ConsoleLoggerProvider((t, l) => true, true));
+
 				if (args.Length != 3)
 				{
-					throw new Exception($"Response file, output path and binlog path are required");
+					throw new Exception($"Response file, output path and binlog path are required.");
 				}
 
 				var responseFilePath = args[0];
@@ -59,6 +64,8 @@ namespace Uno.SourceGeneration.Host
 		{
 			using (var logger = new BinaryLoggerForwarderProvider(binlogOutputPath))
 			{
+				typeof(Program).Log().Info($"Generating files to path {generatedFilesOutputPath}, logoutput={binlogOutputPath}");
+
 				try
 				{
 					var host = new SourceGeneratorHost(environment);

--- a/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
@@ -109,6 +109,7 @@
 								BinLogOutputPath="$(UnoSourceGeneratorBinLogOutputPath)"
 								BinLogEnabled="$(UnoSourceGeneratorUnsecureBinLogEnabled)"
 								UseGenerationHost="$(UnoSourceGeneratorUseGenerationHost)"
+								CaptureGenerationHostOutput="$(UnoCaptureGenerationHostOutput)"
 								Condition="$(_hasSourceGenerators)">
 			<Output TaskParameter="GenereratedFiles" ItemName="UnoGeneratedFiles" />
 		</SourceGenerationTask_v0>

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -60,6 +60,12 @@ namespace Uno.SourceGeneratorTasks
 		public string UseGenerationHost { get; set; }
 
 		/// <summary>
+		/// Capture the generation host standard output for debug purposes.
+		/// (used when UseGenerationHost is set)
+		/// </summary>
+		public string CaptureGenerationHostOutput { get; set; }
+
+		/// <summary>
 		/// Provides a list of assemblies to be loaded in the SourceGenerator
 		/// secondary app domains. This is a backward compatibility feature related
 		/// to the use of external libraries in previous versions of the SourceGeneration task.
@@ -137,6 +143,16 @@ namespace Uno.SourceGeneratorTasks
 
 		private void GenerateWithHost()
 		{
+			var captureHostOutput = false;
+			if (!bool.TryParse(this.CaptureGenerationHostOutput, out captureHostOutput))
+			{
+#if DEBUG
+				captureHostOutput = true; // default to true in DEBUG
+#else
+				captureHostOutput = false; // default to false in RELEASE
+#endif
+			}
+
 			var hostPath = GetHostPath();
 
 			var responseFile = Path.GetTempFileName();
@@ -173,19 +189,47 @@ namespace Uno.SourceGeneratorTasks
 					}
 				}
 
-				var p = Process.Start(buildInfo());
-
-				p.WaitForExit();
-
-				BinaryLoggerReplayHelper.Replay(BuildEngine, binlogFile);
-
-				if (p.ExitCode == 0)
+				using (var process = new Process())
 				{
-					GenereratedFiles = File.ReadAllText(outputFile).Split(';');
-				}
-				else
-				{
-					throw new InvalidOperationException($"Generation failed");
+					var startInfo = buildInfo();
+
+					if (captureHostOutput)
+					{
+
+						startInfo.RedirectStandardOutput = true;
+						startInfo.RedirectStandardError = true;
+
+						process.StartInfo = startInfo;
+						process.Start();
+
+						var output = process.StandardOutput.ReadToEnd();
+						var error = process.StandardError.ReadToEnd();
+						process.WaitForExit();
+
+						this.Log().Info(
+							$"Executing {startInfo.FileName} {startInfo.Arguments}:\n" +
+							$"result: {process.ExitCode}\n" +
+							$"\n---begin host output---\n{output}\n" +
+							$"---begin host ERROR output---\n{error}\n" +
+							"---end host output---\n");
+					}
+					else
+					{
+						process.StartInfo = startInfo;
+						process.Start();
+						process.WaitForExit();
+					}
+
+					BinaryLoggerReplayHelper.Replay(BuildEngine, binlogFile);
+
+					if (process.ExitCode == 0)
+					{
+						GenereratedFiles = File.ReadAllText(outputFile).Split(';');
+					}
+					else
+					{
+						throw new InvalidOperationException($"Generation failed");
+					}
 				}
 			}
 			finally

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -195,7 +195,7 @@ namespace Uno.SourceGeneratorTasks
 
 					if (captureHostOutput)
 					{
-
+						startInfo.Arguments += " -console";
 						startInfo.RedirectStandardOutput = true;
 						startInfo.RedirectStandardError = true;
 


### PR DESCRIPTION
Ability to capture the console output of the generation, when used.
This feature is opt-in.