### PR TITLE
Restore current process generation for msbuild below 16.0

### DIFF
--- a/src/Uno.SourceGenerationHost.Shared/Helpers/BinaryLoggerReplayHelper.cs
+++ b/src/Uno.SourceGenerationHost.Shared/Helpers/BinaryLoggerReplayHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 
@@ -12,13 +13,16 @@ namespace Uno.SourceGeneration.Helpers
 		/// </summary>
 		public static void Replay(IBuildEngine engine, string filePath)
 		{
-			var replaySource = new Microsoft.Build.Logging.BinaryLogReplayEventSource();
+			if (File.Exists(filePath))
+			{
+				var replaySource = new Microsoft.Build.Logging.BinaryLogReplayEventSource();
 
-			replaySource.MessageRaised += (s, e) => engine.LogMessageEvent(e);
-			replaySource.WarningRaised += (s, e) => engine.LogWarningEvent(e);
-			replaySource.ErrorRaised += (s, e) => engine.LogErrorEvent(e);
+				replaySource.MessageRaised += (s, e) => engine.LogMessageEvent(e);
+				replaySource.WarningRaised += (s, e) => engine.LogWarningEvent(e);
+				replaySource.ErrorRaised += (s, e) => engine.LogErrorEvent(e);
 
-			replaySource.Replay(filePath);
+				replaySource.Replay(filePath);
+			}
 		}
 	}
 }

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -228,7 +228,7 @@ namespace Uno.SourceGeneratorTasks
 					}
 					else
 					{
-						throw new InvalidOperationException($"Generation failed");
+						throw new InvalidOperationException($"Generation failed, error code {process.ExitCode}");
 					}
 				}
 			}
@@ -243,8 +243,29 @@ namespace Uno.SourceGeneratorTasks
 
 		public bool NeedsGenerationHost
 			=> (bool.TryParse(UseGenerationHost, out var result) && result)
-			|| RuntimeHelpers.IsMono
+			|| (RuntimeHelpers.IsMono && IsMonoMSBuildCompatible)
 			|| RuntimeHelpers.IsNetCore;
+
+		public bool IsMonoMSBuildCompatible =>
+			// Starting from vs16.0 the following errors does not happen. Below this version, we continue to use
+			// the current process to run the generators.
+			// 
+			// System.TypeInitializationException: The type initializer for 'Microsoft.Build.Collections.MSBuildNameIgnoreCaseComparer' threw an exception. ---> System.EntryPointNotFoundException: GetSystemInfo
+			//   at(wrapper managed-to-native) Microsoft.Build.Shared.NativeMethodsShared.GetSystemInfo(Microsoft.Build.Shared.NativeMethodsShared/SYSTEM_INFO&)
+			//   at Microsoft.Build.Shared.NativeMethodsShared+SystemInformationData..ctor ()[0x00023] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Shared.NativeMethodsShared.get_SystemInformation ()[0x0001e] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Shared.NativeMethodsShared.get_ProcessorArchitecture ()[0x00000] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Collections.MSBuildNameIgnoreCaseComparer..cctor ()[0x00010] in <61115f75067146fab35b10183e6ee379>:0 
+			//    --- End of inner exception stack trace ---
+			//   at Microsoft.Build.Collections.PropertyDictionary`1[T]..ctor ()[0x00006] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Evaluation.ProjectCollection..ctor (System.Collections.Generic.IDictionary`2[TKey, TValue] globalProperties, System.Collections.Generic.IEnumerable`1[T] loggers, System.Collections.Generic.IEnumerable`1[T] remoteLoggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations, System.Int32 maxNodeCount, System.Boolean onlyLogCriticalEvents) [0x00112] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Evaluation.ProjectCollection..ctor(System.Collections.Generic.IDictionary`2[TKey, TValue] globalProperties, System.Collections.Generic.IEnumerable`1[T] loggers, Microsoft.Build.Evaluation.ToolsetDefinitionLocations toolsetDefinitionLocations) [0x00000] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Evaluation.ProjectCollection..ctor(System.Collections.Generic.IDictionary`2[TKey, TValue] globalProperties) [0x00000] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Microsoft.Build.Evaluation.ProjectCollection..ctor() [0x00000] in <61115f75067146fab35b10183e6ee379>:0 
+			//   at Uno.SourceGeneration.Host.ProjectLoader.LoadProjectDetails(Uno.SourceGeneratorTasks.BuildEnvironment environment) [0x00216] in <b845ad5dce324939bc8243d198321524>:0 
+			//   at Uno.SourceGeneration.Host.SourceGeneratorHost.Generate() [0x00014] in <b845ad5dce324939bc8243d198321524>:0 
+
+			string.Compare(FileVersionInfo.GetVersionInfo(new Uri(this.GetType().Assembly.Location).LocalPath).FileVersion, "16.0") >= 0;
 
 		private string GetHostPath()
 		{


### PR DESCRIPTION
Starting from msbuild 16.0 the following error does not happen. Below this version, we continue to use the in-process generation, instead of using the out-of-process generation.

```
System.TypeInitializationException: The type initializer for 'Microsoft.Build.Collections.MSBuildNameIgnoreCaseComparer' threw an exception. ---> System.EntryPointNotFoundException: GetSystemInfo
   at(wrapper managed-to-native) Microsoft.Build.Shared.NativeMethodsShared.GetSystemInfo(Microsoft.Build.Shared.NativeMethodsShared/SYSTEM_INFO&)
```