### PR TITLE
Release builds hosted mode fixes

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,7 +1,5 @@
 phases:
 - phase: VS_Latest
-  variables:
-    NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget
 
   steps:
   - task: NuGetToolInstaller@0

--- a/src/Uno.SourceGeneration.Host/Program.cs
+++ b/src/Uno.SourceGeneration.Host/Program.cs
@@ -8,7 +8,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
-using Microsoft.Extensions.Options;
 using Uno.SourceGeneration.Helpers;
 using Uno.SourceGeneratorTasks;
 using Uno.SourceGeneratorTasks.Helpers;

--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+	<OutputType>Exe</OutputType>
+	<TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
 	<DefineConstants>$(DefineConstants);HAS_BINLOG</DefineConstants>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 	<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
 	<PackageReference Include="ManagedEsent">
 	  <Version>1.9.4</Version>
 	</PackageReference>
@@ -29,29 +29,87 @@
 	  <ExcludeAssets>runtime</ExcludeAssets>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis">
-	  <Version>2.9.0</Version>
+	  <Version>2.3.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.Common">
-	  <Version>2.9.0</Version>
+	  <Version>2.3.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-	  <Version>2.9.0</Version>
+	  <Version>2.3.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-	  <Version>2.9.0</Version>
+	  <Version>2.3.0</Version>
 	</PackageReference>
 	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-	  <Version>2.9.0</Version>
+	  <Version>2.3.0</Version>
 	</PackageReference>
-	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
-	<PackageReference Include="Microsoft.DiaSymReader" Version="1.3.0" />
-	<PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.7.0" />
-	<PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.5.0" />
 	<PackageReference Include="Microsoft.VisualStudio.RemoteControl">
 	  <Version>14.0.262-masterA5CACE98</Version>
 	</PackageReference>
 	<PackageReference Include="Mono.Cecil">
 	  <Version>0.9.6.4</Version>
+	</PackageReference>
+	<PackageReference Include="System.Reflection.Metadata">
+	  <Version>1.4.2</Version>
+	</PackageReference>
+	<PackageReference Include="System.Threading.Tasks.Dataflow">
+	  <Version>4.5.25</Version>
+	</PackageReference>
+	<PackageReference Include="System.Collections.Immutable">
+	  <Version>1.3.1</Version>
+	</PackageReference>
+	<PackageReference Include="System.ValueTuple">
+	  <Version>4.4.0</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.Extensions.Logging">
+	  <Version>1.1.1</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.Extensions.Logging.Console">
+	  <Version>1.1.1</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.Extensions.Logging.Debug">
+	  <Version>1.1.1</Version>
+	</PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+	<PackageReference Include="Microsoft.Build">
+	  <Version>15.4.8</Version>
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	</PackageReference>
+	<PackageReference Include="Microsoft.Build.Framework">
+	  <Version>15.4.8</Version>
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	</PackageReference>
+	<PackageReference Include="Microsoft.Build.Tasks.Core">
+	  <Version>15.4.8</Version>
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	</PackageReference>
+	<PackageReference Include="Microsoft.Build.Utilities.Core">
+	  <Version>15.4.8</Version>
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis">
+	  <Version>2.10.0</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis.Common">
+	  <Version>2.10.0</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+	  <Version>2.10.0</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+	  <Version>2.10.0</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
+	  <Version>2.10.0</Version>
+	</PackageReference>
+	<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.10.0" />
+	<PackageReference Include="Microsoft.DiaSymReader" Version="1.3.0" />
+	<PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.7.0" />
+	<PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.5.0" />
+	<PackageReference Include="Microsoft.VisualStudio.RemoteControl">
+	  <Version>14.0.262-masterA5CACE98</Version>
 	</PackageReference>
 	<PackageReference Include="System.Runtime.Loader">
 	  <Version>4.3.0</Version>
@@ -68,14 +126,17 @@
 	<PackageReference Include="Microsoft.Extensions.Logging.Debug">
 	  <Version>2.0.0</Version>
 	</PackageReference>
+	<PackageReference Include="Mono.Cecil">
+	  <Version>0.9.6.4</Version>
+	</PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-      <Reference Include="System.Runtime.Serialization" />
+	<Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Uno.SourceGeneration\Uno.SourceGeneration.csproj" />
+	<ProjectReference Include="..\Uno.SourceGeneration\Uno.SourceGeneration.csproj" />
   </ItemGroup>
 
   <Import Project="..\Uno.SourceGenerationHost.Shared\Uno.SourceGenerationHost.Shared.projitems" Label="Shared" />

--- a/src/Uno.SourceGenerationHost.Shared/SourceGeneratorHost.cs
+++ b/src/Uno.SourceGenerationHost.Shared/SourceGeneratorHost.cs
@@ -52,7 +52,14 @@ namespace Uno.SourceGeneration.Host
 		{
 			var globalExecution = Stopwatch.StartNew();
 
-			using (var details = ProjectLoader.LoadProjectDetails(_environment))
+			var compilationResult = GetCompilation().Result;
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().Debug($"Got compilation after {globalExecution.Elapsed}");
+			}
+
+			using (var details = ProjectLoader.LoadProjectDetails(_environment, BuildGlobalMSBuildProperties()))
 			{
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
@@ -63,13 +70,6 @@ namespace Uno.SourceGeneration.Host
 				{
 					this.Log().Info($"No generators were found.");
 					return new string[0];
-				}
-
-				var compilationResult = GetCompilation().Result;
-
-				if (this.Log().IsEnabled(LogLevel.Debug))
-				{
-					this.Log().Debug($"Got compilation after {globalExecution.Elapsed}");
 				}
 
 				// Build dependencies graph
@@ -243,41 +243,15 @@ namespace Uno.SourceGeneration.Host
 		{
 			try
 			{
-				var globalProperties = new Dictionary<string, string> {
-							{ "Configuration", _environment.Configuration },
-							{ "BuildingInsideVisualStudio", "true" },
-							{ "BuildingInsideUnoSourceGenerator", "true" },
-							{ "DesignTimeBuild", "true" },
-							{ "UseHostCompilerIfAvailable", "false" },
-							{ "UseSharedCompilation", "false" },
-							{ "IntermediateOutputPath", Path.Combine(_environment.OutputPath, "obj") + Path.DirectorySeparatorChar },
-							{ "VisualStudioVersion", _environment.VisualStudioVersion },
+				var globalProperties = BuildGlobalMSBuildProperties();
 
-							// The Platform is intentionally not set here
-							// as for now, Roslyn applies the properties to all 
-							// loaded projects, directly or indirectly.
-							// So for now, we rely on the fact that all projects
-							// have a default platform directive, and that most projects
-							// don't rely on the platform to adjust the generated code.
-							// (e.g. _platform may be iPhoneSimulator, but all projects may not
-							// support this target, and therefore will fail to load.
-							//{ "Platform", _platform },
-						};
-
-				if (_environment.TargetFramework.HasValue())
-				{
-					// Target framework is required for the MSBuild 15.0 Cross Compilation.
-					// Loading a project without the target framework results in an empty project, which interatively
-					// sets the TargetFramework property.
-					globalProperties.Add("TargetFramework", _environment.TargetFramework);
-				}
-
-				// TargetFrameworkRootPath is used by VS4Mac to determine the
-				// location of frameworks like Xamarin.iOS.
-				if (_environment.TargetFrameworkRootPath.HasValue())
-				{
-					globalProperties["TargetFrameworkRootPath"] = _environment.TargetFrameworkRootPath;
-				}
+				//globalProperties.Remove("DesignTimeBuild");
+				//globalProperties.Remove("BuildingInsideVisualStudio");
+				//globalProperties.Remove("BuildProjectReferences");
+				//globalProperties.Remove("BuildingProject");
+				//globalProperties.Remove("ProvideCommandLineArgs");
+				//globalProperties.Remove("SkipCompilerExecution");
+				//globalProperties.Remove("ContinueOnError");
 
 				var ws = MSBuildWorkspace.Create(globalProperties);
 
@@ -296,7 +270,7 @@ namespace Uno.SourceGeneration.Host
 
 				if (metadataLessProjects.Any())
 				{
-					foreach(var diag in ws.Diagnostics)
+					foreach (var diag in ws.Diagnostics)
 					{
 						this.Log().Debug($"[{diag.Kind}] {diag.Message}");
 					}
@@ -344,6 +318,59 @@ namespace Uno.SourceGeneration.Host
 					throw new InvalidOperationException(e.ToString());
 				}
 			}
+		}
+
+		private Dictionary<string, string> BuildGlobalMSBuildProperties()
+		{
+			var globalProperties = new Dictionary<string, string> {
+				// Default global properties defined in Microsoft.CodeAnalysis.MSBuild.Build.ProjectBuildManager
+				// https://github.com/dotnet/roslyn/blob/b9fb1610c87cccc8ceb74a770dba261a58e39c4a/src/Workspaces/Core/MSBuild/MSBuild/Build/ProjectBuildManager.cs#L24
+				{ "BuildingInsideVisualStudio", bool.TrueString },
+				{ "BuildProjectReferences", bool.FalseString },
+				// this will tell msbuild to not build the dependent projects
+				{ "DesignTimeBuild", bool.TrueString },
+				// don't actually run the compiler
+				{ "SkipCompilerExecution", bool.TrueString },
+
+				{ "UseHostCompilerIfAvailable", bool.FalseString },
+				{ "UseSharedCompilation", bool.FalseString },
+
+				// Prevent the generator to recursively execute
+				{ "BuildingInsideUnoSourceGenerator", bool.TrueString },
+				{ "Configuration", _environment.Configuration },
+
+				// Override the output path so custom compilation lists do not override the
+				// main compilation caches, which can invalidate incremental compilation.
+				{ "IntermediateOutputPath", Path.Combine(_environment.OutputPath, "obj") + Path.DirectorySeparatorChar },
+				{ "VisualStudioVersion", _environment.VisualStudioVersion },
+
+				// The Platform is intentionally not set here
+				// as for now, Roslyn applies the properties to all 
+				// loaded projects, directly or indirectly.
+				// So for now, we rely on the fact that all projects
+				// have a default platform directive, and that most projects
+				// don't rely on the platform to adjust the generated code.
+				// (e.g. _platform may be iPhoneSimulator, but all projects may not
+				// support this target, and therefore will fail to load.
+				//{ "Platform", _platform },
+			};
+
+			if (_environment.TargetFramework.HasValue())
+			{
+				// Target framework is required for the MSBuild 15.0 Cross Compilation.
+				// Loading a project without the target framework results in an empty project, which interatively
+				// sets the TargetFramework property.
+				globalProperties.Add("TargetFramework", _environment.TargetFramework);
+			}
+
+			// TargetFrameworkRootPath is used by VS4Mac to determine the
+			// location of frameworks like Xamarin.iOS.
+			if (_environment.TargetFrameworkRootPath.HasValue())
+			{
+				globalProperties["TargetFrameworkRootPath"] = _environment.TargetFrameworkRootPath;
+			}
+
+			return globalProperties;
 		}
 
 		private async Task<(Compilation compilation, Project project)> AddToCompilation(


### PR DESCRIPTION
# PR Type
- Bugfix

## What is the current behavior?
Release builds using the hosted mode fail with `an equivalent project (a project with the same global properties and tools version) has already been loaded`


## What is the new behavior?
Release builds are not failing anymore, until an update to Roslyn msbuild workspace is able to discriminate between loaded projects properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/ReleaseNotes)
