### PR TITLE
Copy all files to the netcoreapp2.1 output folder

### DIFF
--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -6,6 +6,7 @@
 	<DefineConstants>$(DefineConstants);HAS_BINLOG</DefineConstants>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 	<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">


### PR DESCRIPTION
Fixes #62

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The host process for netcoreapp2.1 does not contain proper dependencies


## What is the new behavior?
The host process for netcoreapp2.1 contains proper dependencies, making it run properly for `dotnet build`.
