### PR TITLE
Adjust target framework matrix support

### DIFF
--- a/build/Uno.SourceGenerationTasks.nuspec
+++ b/build/Uno.SourceGenerationTasks.nuspec
@@ -21,12 +21,8 @@
 	<file src="..\src\Uno.SourceGeneration.Host\bin\Release\net462\*.*" target="build\host\net462" />
 	<file src="..\src\Uno.SourceGeneration.Host\bin\Release\netcoreapp2.1\*.*" target="build\host\netcoreapp2.1" />
 
-	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\net45" />
-	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\uap" />
-	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\MonoAndroid" />
-	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\Xamarin.iOS10" />
-	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\Xamarin.Mac20" />
+	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\netstandard1.0" />
 	
-	<file src="_._"  target="lib/netstandard2.0" />
+	<file src="_._"  target="lib/netstandard1.0" />
   </files>
 </package>


### PR DESCRIPTION
Force the use of netstandard 1.0 for all targets, so the build targets get included in all available TF.
