### PR TITLE
Adjust for .NET 4.6.1 minimum for .NET Standard 2.0 compatibility.

### DIFF
--- a/build/Uno.SourceGeneration.nuspec
+++ b/build/Uno.SourceGeneration.nuspec
@@ -27,6 +27,6 @@
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="..\src\Uno.SourceGeneration\Bin\Release\net462\Uno.SourceGeneration.dll" target="lib/net462/Uno.SourceGeneration.dll" />
+		<file src="..\src\Uno.SourceGeneration\Bin\Release\net461\Uno.SourceGeneration.dll" target="lib/net461/Uno.SourceGeneration.dll" />
 	</files>
 </package>

--- a/build/Uno.SourceGenerationTasks.nuspec
+++ b/build/Uno.SourceGenerationTasks.nuspec
@@ -18,7 +18,7 @@
 	<file src="..\src\Uno.SourceGeneratorTasks.Dev15.0\Bin\Release\*.pdb" target="build\Dev15.0" />
 	<file src="..\src\Uno.SourceGeneratorTasks.Dev15.0\Bin\Release\*.config" target="build\Dev15.0" />
 
-	<file src="..\src\Uno.SourceGeneration.Host\bin\Release\net462\*.*" target="build\host\net462" />
+	<file src="..\src\Uno.SourceGeneration.Host\bin\Release\net461\*.*" target="build\host\net461" />
 	<file src="..\src\Uno.SourceGeneration.Host\bin\Release\netcoreapp2.1\*.*" target="build\host\netcoreapp2.1" />
 
 	<file src="..\src\Uno.SourceGeneratorTasks.Shared\Content\Uno.SourceGenerationTasks.targets" target="build\netstandard1.0" />

--- a/src/Uno.SampleGenerators/Uno.SampleGenerators.csproj
+++ b/src/Uno.SampleGenerators/Uno.SampleGenerators.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Uno.SampleGenerators</RootNamespace>
     <AssemblyName>Uno.SampleGenerators</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StartAction>Program</StartAction>
     <StartProgram>$(DevEnvDir)..\..\MSBuild\15.0\Bin\MSBuild.exe</StartProgram>

--- a/src/Uno.SampleProject/Uno.SampleProject.csproj
+++ b/src/Uno.SampleProject/Uno.SampleProject.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Uno.SampleProject</RootNamespace>
     <AssemblyName>Uno.SampleProject</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Uno.SourceGeneration.Host/AssemblyResolver.cs
+++ b/src/Uno.SourceGeneration.Host/AssemblyResolver.cs
@@ -108,7 +108,7 @@ namespace Uno.SourceGeneration.Host
 					.FirstOrDefault();
 			};
 
-#if NET462
+#if NET461
 			AppDomain.CurrentDomain.AssemblyResolve += (s, e) => localResolve(new AssemblyName(e.Name));
 			AppDomain.CurrentDomain.TypeResolve += (s, e) => localResolve(new AssemblyName(e.Name));
 #elif NETCOREAPP

--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
 	<OutputType>Exe</OutputType>
-	<TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+	<TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
 	<DefineConstants>$(DefineConstants);HAS_BINLOG</DefineConstants>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 	<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
 	<PackageReference Include="ManagedEsent">
 	  <Version>1.9.4</Version>
 	</PackageReference>

--- a/src/Uno.SourceGeneration/Uno.SourceGeneration.csproj
+++ b/src/Uno.SourceGeneration/Uno.SourceGeneration.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netcoreapp2.1;net462</TargetFrameworks>
+	<TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
 	<DefineConstants>$(DefineConstants);HAS_BINLOG</DefineConstants>
 	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 	<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
 	<PackageReference Include="Microsoft.Build">
 	  <Version>14.3.0</Version>
 	</PackageReference>

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Uno.SourceGeneratorTasks.Dev15.0.csproj
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Uno.SourceGeneratorTasks.Dev15.0.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Uno.SourceGeneratorTasks</RootNamespace>
     <AssemblyName>Uno.SourceGeneratorTasks.v0</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
     <TargetFrameworkProfile />
@@ -127,7 +127,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\Uno.SourceGenerationHost.Shared\Uno.SourceGenerationHost.Shared.projitems" Label="Shared" />
   <Import Project="..\Uno.SourceGeneratorTasks.Shared\Uno.SourceGeneratorTasks.Shared.projitems" Label="Shared" />

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/app.config
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/app.config
@@ -60,4 +60,4 @@
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Shared/Tasks/SourceGenerationTask.cs
@@ -280,7 +280,7 @@ namespace Uno.SourceGeneratorTasks
 		private string GetHostPath()
 		{
 			var currentPath = Path.GetDirectoryName(new Uri(GetType().Assembly.CodeBase).LocalPath);
-			var hostPlatform = RuntimeHelpers.IsNetCore ? "netcoreapp2.1" : "net462";
+			var hostPlatform = RuntimeHelpers.IsNetCore ? "netcoreapp2.1" : "net461";
 			var installedPath = Path.Combine(currentPath, "..", "host", hostPlatform);
 #if DEBUG
 			var configuration = "Debug";


### PR DESCRIPTION
GitHub Issue (If applicable): Closes #70

## PR Type
What kind of change does this PR introduce?

Adjust package minimum .NET version to 4.6.1, the minimum version to be compatible with .NET Standard 2.0.or internal)