### PR TITLE
Add workaround for unknown android designer file

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -12,3 +12,4 @@
 ### Breaking changes
 
 ### Bug fixes
+- Added workaround for missing designer file error with Xamarin.Android projects

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -5,6 +5,9 @@
 ### Features
 - Improve error message when a cross targeted project is misconfigured (#25)
 - Add Linux build support
+- Nuget packages are now signed with Authenticode.
+- Support for VS2019 16.0 Pre 1
+- Pass-through support for F# and VB.NET projects
 
 ### Breaking changes
 

--- a/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Shared/Content/Uno.SourceGenerationTasks.targets
@@ -148,4 +148,20 @@
 		</ItemGroup>
 	</Target>
 
+  <Target Name="InvalidAndroidDesignerWorkaround"
+          AfterTargets="UpdateGeneratedFiles"
+          Condition=" '$(BuildingInsideUnoSourceGenerator)' != '' and ('$(_UnoSourceGeneratorProjectType)'=='android' or '$(TargetFrameworkIdentifier)'=='MonoAndroid')">
+
+	<!--
+	During the loading of a Xamarin.Android project, when AndroidUseIntermediateDesignerFile is set to true, the
+	designer file is added to the compilation list, even though it's not present. This makes the msbuild roslyn workspace
+	try to build this file, raising a error that is not significant as the result of the build is not used.
+
+	This target removes that file from the compilation list when the project is loaded inside the source generators
+	-->
+	<ItemGroup>
+	  <Compile Remove="$(_AndroidResourceDesignerFile)" />
+	</ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Building android project with `AndroidUseIntermediateDesignerFile` set to `true` gives the following false-positive error: 
`Error [Failure] Could not find file 'C:\xxxx.Droid\obj\Debug\80\g\obj\Resource.designer.cs'`

## What is the new behavior?
During the loading of a Xamarin.Android project, when AndroidUseIntermediateDesignerFile is set to true, the designer file is added to the compilation list, even though it's not present. This makes the msbuild roslyn workspace try to build this file, raising a error that is not significant as the result of the build is not used. 

This added target removes that file from the compilation list when the project is loaded inside the source generators.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
This will fix this issue: https://github.com/nventive/Uno/issues/337
