### PR TITLE
Restore the UnoSourceGeneratoCaptureGenerationHostOutput parameter.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,17 @@ allows for an improved diagnostics experience. Set the `UnoSourceGeneratorUnsecu
 
 > **Important**: The binary logger may leak secret environment variables, it is a best practice to never enable this feature as part of normal build.
 
+### My build ends with error code 3
+
+By default, in some cases, the source generation host will run into an internal error, and will exit without providing details about the generation error.
+
+To enable the logging of these errors, add the following property to your project:
+```xml
+<UnoSourceGeneratorCaptureGenerationHostOutput>true</UnoSourceGeneratorCaptureGenerationHostOutput>
+```
+
+The errors will the be visible when the build logging output is set to detailed, or by [using the binary logger](https://github.com/Microsoft/msbuild/blob/master/documentation/wiki/Binary-Log.md).
+
 # Have questions? Feature requests? Issues?
 
 Make sure to visit our [StackOverflow](https://stackoverflow.com/questions/tagged/uno-platform), [create an issue](https://github.com/nventive/Uno.SourceGeneration/issues) or [visit our gitter](https://gitter.im/uno-platform/Lobby).

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Content/Uno.SourceGenerationTasks.targets
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Content/Uno.SourceGenerationTasks.targets
@@ -106,6 +106,7 @@
 								TargetFrameworkRootPath="$(TargetFrameworkRootPath)"
 								AdditionalAssemblies="@(SourceGeneratorAdditionalAssemblies)"
 								UseGenerationController="$(UnoSourceGeneratorUseGenerationController)"
+								CaptureGenerationHostOutput="$(UnoSourceGeneratorCaptureGenerationHostOutput)"
 								BinLogOutputPath="$(UnoSourceGeneratorBinLogOutputPath)"
 								BinLogEnabled="$(UnoSourceGeneratorUnsecureBinLogEnabled)"
 								Condition="$(_hasSourceGenerators)">

--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
@@ -224,7 +224,7 @@ namespace Uno.SourceGeneratorTasks
 		{
 			Log.LogMessage(MessageImportance.Low, $"Using single-use host generation mode");
 
-var captureHostOutput = false;
+			var captureHostOutput = false;
 			if (!bool.TryParse(this.CaptureGenerationHostOutput, out captureHostOutput))
 			{
 #if DEBUG


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
If the source generation fails with error code 3, it's not possible to view the exception.

## What is the new behavior?
The UnoSourceGeneratoCaptureGenerationHostOutput property is restored, to view the output in the build log.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.SourceGeneration/tree/master/doc/ReleaseNotes)
