### PR TITLE
Restore console output for single-use generation

### DIFF
--- a/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
+++ b/src/Uno.SourceGeneratorTasks.Dev15.0/Tasks/SourceGenerationTask.cs
@@ -224,6 +224,9 @@ namespace Uno.SourceGeneratorTasks
 		{
 			Log.LogMessage(MessageImportance.Low, $"Using single-use host generation mode");
 
+			var taskLogger = new TaskLoggerProvider() { TaskLog = Log };
+			LogExtensionPoint.AmbientLoggerFactory.AddProvider(taskLogger);
+
 			var captureHostOutput = false;
 			if (!bool.TryParse(this.CaptureGenerationHostOutput, out captureHostOutput))
 			{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Enabling `UnoSourceGeneratorCaptureGenerationHostOutput` shows additional information in the build log.
