### PR TITLE
Adjust for macOS build error.

### DIFF
--- a/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
+++ b/src/Uno.SourceGeneration.Host/Uno.SourceGeneration.Host.csproj
@@ -60,6 +60,9 @@
 	<PackageReference Include="System.Collections.Immutable">
 	  <Version>1.3.1</Version>
 	</PackageReference>
+	<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
+	  <Version>4.0.1</Version>
+	</PackageReference>
 	<PackageReference Include="System.ValueTuple">
 	  <Version>4.4.0</Version>
 	</PackageReference>
@@ -141,11 +144,6 @@
 	<PackageReference Include="Mono.Cecil">
 	  <Version>0.9.6.4</Version>
 	</PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="bin\Debug\net461\System.Native.a" />
-    <None Include="bin\Debug\net461\System.Native.so" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Getting `The type initializer for 'Microsoft.Build.Collections.MSBuildNameIgnoreCaseComparer' threw an exception.` on macOS.

## What is the new behavior?
Tentative use workaround specified here: https://github.com/dotnet/docfx/issues/2358
